### PR TITLE
Set name of dashboard browser path based on filename

### DIFF
--- a/routes/routes.js
+++ b/routes/routes.js
@@ -49,7 +49,7 @@ function _renderList(req, res, list, next) {
             res.render('list', {
                 username: req.session.username,
                 items: values,
-                title: 'List of Dashboards',
+                title: 'Dashboards',
                 url: req.params[0]
             });
         },
@@ -124,9 +124,12 @@ router.get('/dashboards/*', function(req, res, next) {
             nbstore.get(dbpath).then(
                 function success(notebook) {
                     debug('Success loading nb');
+
+                    var nbname = path.basename(dbpath, dbExt);
+
                     res.status(200);
                     res.render('dashboard', {
-                        title: 'Dashboard',
+                        title: nbname,
                         notebook: notebook,
                         username: req.session.username
                     });


### PR DESCRIPTION
This puts us at same level as Notebook, where title of the notebook is the name of the file.

Further work could be done to pull a more descriptive title from first header in notebook's first cell, but we would diverge from (classic) Jupyter Notebook.

Fixes #90