### PR TITLE
Pass along decoded notebook path

### DIFF
--- a/public/js/kernel.js
+++ b/public/js/kernel.js
@@ -27,7 +27,7 @@ define([
             clientId: clientId,
             ajaxSettings: {
                 requestHeaders: {
-                    'X-jupyter-notebook-path': window.location.pathname,
+                    'X-jupyter-notebook-path': decodeURIComponent(loc.pathname),
                     'X-jupyter-session-id': clientId
                 }
             }


### PR DESCRIPTION
Makes it so notebook names with spaces in them aren't evaluated
with a "%20" instead of a space.

Fixes #111