### PR TITLE
[Issue 56] Ensure notebook order when executing cells.

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -144,6 +144,11 @@ requirejs([
     // NOTE: DeclWidgets adds 'urth_components/...' to this path
     DeclWidgets.init('/');
 
+    function _getCodeCells() {
+        return $('.dashboard-cell.code-cell').sort(function(a, b) {
+            return $(a).attr('data-cell-index') - $(b).attr('data-cell-index');
+        });
+    }
 
     // start a kernel
     Kernel.start().then(function(kernel) {
@@ -151,7 +156,7 @@ requirejs([
         var widgetManager = new WidgetManager(kernel, _consumeMessage);
         _registerKernelErrorHandler(kernel);
 
-        $('.dashboard-cell.code-cell').each(function() {
+        _getCodeCells().each(function() {
             var $cell = $(this);
 
             // create a jupyter output area mode and widget view for each
@@ -176,7 +181,7 @@ requirejs([
             $cell.append($widgetArea, view.node);
 
             // request execution of the code associated with the dashboard cell
-            var kernelFuture = Kernel.execute($cell.index(), function(msg) {
+            var kernelFuture = Kernel.execute($cell.attr('data-cell-index'), function(msg) {
                 // handle the response to the initial execution request
                 if (model) {
                     _consumeMessage(msg, model);

--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -22,13 +22,14 @@
             {{#if metadata.urth.dashboard.layout}}
                 {{#with metadata.urth.dashboard.layout}}
                     <div class="cell dashboard-cell grid-stack-item {{mapCellType ../cell_type}}"
+                        data-cell-index={{@index}}
                         data-gs-x={{col}}
                         data-gs-y={{row}}
                         data-gs-width={{width}}
                         data-gs-height={{height}}>{{{markdownContent ../cell_type ../source}}}</div>
                 {{/with}}
             {{else}}
-                <div class="cell dashboard-cell hidden {{mapCellType cell_type}}"></div>
+                <div class="cell dashboard-cell hidden {{mapCellType cell_type}}" data-cell-index={{@index}}></div>
             {{/if}}
         {{/each}}
     </div>


### PR DESCRIPTION
We were using DOM order. Added data-cell-index attr to sort cells in notebook order.

Resolves #56 