### PR TITLE
[Issue: 31] Allow dashboard clients to reconnect to running kernel

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -25,7 +25,4 @@ config.set('NOTEBOOKS_DIR', path.join(__dirname, '..', config.get('NOTEBOOKS_DIR
 config.set('DB_FILE_EXT', '.ipynb');
 config.set('DB_INDEX', 'index.ipynb');
 
-// how long to keep a kernel alive and reconnectable after its WS connection drops
-config.set('KG_KERNEL_RETENTIONTIME', 120000);
-
 module.exports = config;

--- a/app/config.js
+++ b/app/config.js
@@ -25,4 +25,7 @@ config.set('NOTEBOOKS_DIR', path.join(__dirname, '..', config.get('NOTEBOOKS_DIR
 config.set('DB_FILE_EXT', '.ipynb');
 config.set('DB_INDEX', 'index.ipynb');
 
+// how long to keep a kernel alive and reconnectable after its WS connection drops
+config.set('KG_KERNEL_RETENTIONTIME', 120000);
+
 module.exports = config;

--- a/config.json
+++ b/config.json
@@ -36,6 +36,8 @@
     KG_AUTH_TOKEN: null
     // Kernel gateway base URL (gets appended to KERNEL_GATEWAY_URL)
     KG_BASE_URL: ""
+    // Delay kernel cleanup for this many milliseconds to allow a client to reconnect
+    KG_KERNEL_RETENTIONTIME: 30000
 
     //////////////////////////////
     // Dashboard rendering options

--- a/routes/api.js
+++ b/routes/api.js
@@ -178,11 +178,17 @@ function setupWSProxy(_server) {
         }
         var query = url.parse(req.url, true).query;
         var sessionId = query['session_id'];
+
+        // Check if this is a reconnection
         if (disconnectedKernels[sessionId]) {
             debug('PROXY: WS reattaching to ' + sessionId);
             clearTimeout(disconnectedKernels[sessionId]);
             delete disconnectedKernels[sessionId];
         }
+
+        // Setup a handler that schedules deletion of running kernels after
+        // a timeout to give clients that accidentally disconnected time to
+        // reconnect.
         socket.on('close', function() {
             debug('PROXY: WS will kill kernel ' + kernelId + ' session ' + sessionId + ' soon');
             var waiting = setTimeout(function(sessionId, kernelId) {


### PR DESCRIPTION
Fixes #31. Subsumes #142 to move config location.