### PR TITLE
[issue: 168] Option to pass user auth to kernel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
-bower_components
-ext
-node_modules
+.git/
+node_modules/
+etc/notebooks/

--- a/Dockerfile.kernel
+++ b/Dockerfile.kernel
@@ -3,7 +3,7 @@
 
 FROM jupyter/pyspark-notebook:0017b56d93c9
 
-RUN pip install jupyter_kernel_gateway==0.3.1
+RUN pip install jupyter_kernel_gateway==0.5.0
 # install ipywidgets from github for now (5.x branch)
 RUN pip uninstall -y ipywidgets && \
     pip install git+https://github.com/ipython/ipywidgets.git@b1fb44dad39d86222db5edf98db3935fe2b09c18

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -38,7 +38,9 @@ RUN npm install --quiet
 # add everything else
 USER root
 ADD . /home/node/app
-RUN chown -R node:node /home/node/app
+RUN chown node:node /home/node/app && \
+    chown -R node:node /home/node/app/data && \
+    chown -R node:node /home/node/app/public
 USER node
 
 # build our node app

--- a/app.js
+++ b/app.js
@@ -124,6 +124,7 @@ if (config.get('PRESENTATION_MODE')) {
 }
 app.use('/api', apiRoutes);
 
+
 /////////////////
 // ERROR HANDLING
 /////////////////

--- a/config.json
+++ b/config.json
@@ -40,6 +40,9 @@
     KG_BASE_URL: ""
     // Delay kernel cleanup for this many milliseconds to allow a client to reconnect
     KG_KERNEL_RETENTIONTIME: 30000
+    // Forward auth strategy user profile to every kernel launched for every dashboard visited on the server
+    // e.g., so the kernel can re-use an auth token to access an external service
+    KG_FORWARD_USER_AUTH: false
 
     //////////////////////////////
     // Dashboard rendering options

--- a/etc/notebooks/test/test_env_vars.ipynb
+++ b/etc/notebooks/test/test_env_vars.ipynb
@@ -1,0 +1,69 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "urth": {
+     "dashboard": {}
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pprint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 0,
+       "height": 22,
+       "row": 0,
+       "width": 12
+      }
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pprint.pprint(dict(os.environ))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.4"
+  },
+  "urth": {
+   "dashboard": {
+    "cellMargin": 10,
+    "defaultCellHeight": 20,
+    "layoutStrategy": "packed",
+    "maxColumns": 12
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/public/js/kernel.js
+++ b/public/js/kernel.js
@@ -33,8 +33,7 @@ define([
             }
         };
 
-        return Services.startNewKernel(kernelOptions)
-            .then(function(kernel) {
+        return Services.startNewKernel(kernelOptions).then(function(kernel) {
                 _kernel = kernel;
 
                 // show a busy indicator when communicating with kernel


### PR DESCRIPTION
Damn near impossible to modify the outgoing body of a proxied request which is what #168 requires. So ...

* Move kernel creation logic to a standard route
* Move all special case tracking performed after kernel creation to that route
* Inject auth info if `KG_FORWARD_USER_AUTH` is set (PS: don't assign to a module global like the others since we want to vary it during testing)
* Upgrade kernel gateway to 0.5.0 for env var support
* Add a test notebook/dashboard that print all env vars for manual testing
* Add unit tests

Fixes #168