### PR TITLE
Fix problems from #168

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 .git/
 node_modules/
-etc/notebooks/


### PR DESCRIPTION
* Don't pass all request headers to /api/kernels to avoid
  ping-ponging requests when Host/Origin are unexpected
* Fix random test failures by stubbing request.Request so that
  async callbacks we don't care about never happen
* Fix integration test breakage: integration-test requires
  etc/notebooks for the docker build so we can't ignore it
