### PR TITLE
[issue: 178] Immediately load index/index.ipynb bundles

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -26,6 +26,7 @@ config.set('NOTEBOOKS_DIR', path.join(__dirname, '..', config.get('NOTEBOOKS_DIR
 // TODO Move vars to own module
 config.set('DB_FILE_EXT', '.ipynb');
 config.set('DB_INDEX', 'index.ipynb');
+config.set('DB_INDEX_DIR', 'index')
 
 var key_file_location = config.get('HTTPS_KEY_FILE');
 var cert_file_location = config.get('HTTPS_CERT_FILE');

--- a/routes/renderers.js
+++ b/routes/renderers.js
@@ -134,7 +134,7 @@ function _render(req, res, next, opts) {
                 }); 
             } else if (stats.isDirectory()) {
                 // check if an index bundle exists in this path
-                var dbpathIndex = path.join(dbpath, DB_INDEX_DIR, DB_INDEX);
+                var dbpathIndex = urljoin(dbpath, DB_INDEX_DIR, DB_INDEX);
 
                 // If the path exists on disk and is a normal directory, check
                 // if it contains an index bundle.
@@ -143,7 +143,7 @@ function _render(req, res, next, opts) {
                         // If it does contain an index bundle, redirect to it.
                         // We can't render it from because requests for static
                         // assets from the frontend will fail (off by one path).
-                        res.redirect(path.join(req.path, DB_INDEX_DIR));
+                        res.redirect(urljoin(req.path, DB_INDEX_DIR));
                     })
                     .catch(function() { 
                         // If the directory does not contain an index bundle,
@@ -158,7 +158,7 @@ function _render(req, res, next, opts) {
                         }
                     });
             } else {
-                // If the path is neither a dashboard or a directory, send it
+                // If the path is neither a dashboard nor a directory, send it
                 // as a regular file.
                 res.sendFile(stats.fullpath);
             }

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -9,11 +9,6 @@ var config = require('../app/config');
 var renderers = require('./renderers');
 var router = require('express').Router();
 
-/* GET / - index notebook or list of files */
-router.get('/', function(req, res, next) {
-    renderers.render(req, res, next);
-});
-
 /* GET /dashboards/* - a single dashboard or list of files (subdirectories) */
 router.get('/dashboards(/*)?', function(req, res, next) {
     renderers.render(req, res, next);
@@ -24,6 +19,11 @@ router.get('/dashboards-plain(/*)?', function(req, res, next) {
     renderers.render(req, res, next, {
         hideChrome: true
     });
+});
+
+/* GET / - same as /dashboards/* for user convenience */
+router.get('/(*)?', function(req, res, next) {
+    renderers.render(req, res, next);
 });
 
 module.exports = router;


### PR DESCRIPTION
* If a directory contains a folder named index which itself contains an index.ipynb, redirect to it immediately in place of showing a directory listing (i.e., makes bundled dashboards named index behave like unbundled dashboards named index.ipynb)
* Allow access to /dashboards/* under /* by adjusting route ordering and patterns slightly (previously, only the root (/) listing or index.ipynb was accessible without /dashboards)
* Comment the hell out of the renderer.render logic

Fixes #178
