### PR TITLE
[WIP] [Issue 97] Use higher-level WebSocketConnection instead of *Frame

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "gulp build",
     "start": "node ./bin/www",
     "start-debug": "node-inspector & node --debug-brk ./bin/www",
-    "start-logging": "NODE_DEBUG=http DEBUG=express:*,dashboard-proxy:* node ./bin/www",
+    "start-logging": "NODE_DEBUG=http DEBUG=express:*,dashboard-proxy:*,websocket:* node ./bin/www",
     "test": "mocha test/base/**/*-test.js",
     "integration-test": "mocha test/integration/default/**/*-test.js",
     "integration-test-auth-token": "mocha test/integration/auth-token/**/*-test.js",


### PR DESCRIPTION
Should handle large messages that are sent across multiple WS frames (which we don't currently handle and instead just error out).

This does allow WS messages: client <> proxy <> kernel gateway. However, not currently doing message rewriting.

Ref #97