### PR TITLE
[Issue: 177] Update test_plotting_libs notebook Plotly install

### DIFF
--- a/etc/notebooks/test/test_plotting_libs.ipynb
+++ b/etc/notebooks/test/test_plotting_libs.ipynb
@@ -295,7 +295,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install git+git://github.com/dalogsdon/plotly.py.git@requirePlotly"
+    "!pip install plotly"
    ]
   },
   {


### PR DESCRIPTION
Update the pip install of plotly to use the default version.

Fixes #177 