### PR TITLE
[Issue: 146] <img> styling differs from Notebook

### DIFF
--- a/less/notebook.less
+++ b/less/notebook.less
@@ -55,6 +55,11 @@
             margin-top: 1em;
         }
     }
+    img {
+        display: block;
+        margin-left: auto;
+        margin-right: auto;
+    }
 }
 
 .jp-OutputArea {


### PR DESCRIPTION
    Adopt the auto margin values from the notebook for rendered img
    elements.
(c) Copyright IBM Corp. 2016