### PR TITLE
[Enhancement] Split notebook-store into multiple modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 # Global params
 DASHBOARD_CONTAINER_NAME:=dashboard-server
 DASHBOARD_IMAGE_NAME:=jupyter-incubator/$(DASHBOARD_CONTAINER_NAME)
+DASHBOARD_SERVER_LINK?=http://$$(docker-machine ip $$(docker-machine active)):3000
 INSTALLED_DASHBOARD_IMAGE_NAME:=jupyter-incubator/$(DASHBOARD_CONTAINER_NAME)-installed
 KG_IMAGE_NAME:=jupyter-incubator/kernel-gateway-extras
 KG_CONTAINER_NAME:=kernel-gateway
@@ -84,7 +85,8 @@ define DASHBOARD_SERVER
 	-e HTTPS_PORT=$(HTTPS_PORT) \
 	-e HTTPS_KEY_FILE=$(HTTPS_KEY_FILE) \
 	-e HTTPS_CERT_FILE=$(HTTPS_CERT_FILE) \
-	-e SESSION_SECRET_TOKEN=$(SESSION_SECRET_TOKEN)
+	-e SESSION_SECRET_TOKEN=$(SESSION_SECRET_TOKEN) \
+	-e PUBLIC_LINK=$(DASHBOARD_SERVER_LINK)
 endef
 
 ############### Kernel gateway in a Docker container

--- a/app/append-ext.js
+++ b/app/append-ext.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+/**
+ * Appends the specified extension if necessary.
+ */
+var path = require('path');
+var DB_EXT = require('./config').get('DB_FILE_EXT');
+module.exports = function (nbpath, ext) {
+    ext = ext || '';
+    return nbpath + (path.extname(nbpath) === ext ? '' : ext);
+};

--- a/app/config.js
+++ b/app/config.js
@@ -71,4 +71,10 @@ if (key_file_location || cert_file_location) {
     });
 }
 
+// set base link
+if (!config.get('PUBLIC_LINK')) {
+    var _protocol = config.get('SSL_OPTIONS') ? 'https' : 'http';
+    config.set('PUBLIC_LINK', _protocol + '://' + config.get('IP') + ':' + config.get('PORT'));
+}
+
 module.exports = config;

--- a/app/notebook-fs.js
+++ b/app/notebook-fs.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+/**
+ * Augmented fs functions for notebook files.
+ */
+var appendExt = require('./append-ext');
+var config = require('./config');
+var fs = require('fs');
+var path = require('path');
+
+var DATA_DIR = config.get('NOTEBOOKS_DIR');
+var DB_EXT = config.get('DB_FILE_EXT');
+var INDEX_NB_NAME = config.get('DB_INDEX');
+
+function _ensureDataPath(nbpath) {
+    return nbpath.indexOf(DATA_DIR) === 0 ? nbpath : path.join(DATA_DIR, nbpath);
+}
+
+function _exists(nbpath) {
+    return new Promise(function(resolve, reject) {
+        nbpath = _ensureDataPath(nbpath);
+        fs.stat(nbpath, function(err, stats) {
+            if (err) {
+                if (err.code === 'ENOENT') { // file not found
+                    resolve(false);
+                } else {
+                    reject(err);
+                }
+            } else {
+                resolve(stats.isFile());
+            }
+        });
+    });
+}
+
+function _statError(err, nbpath) {
+    var e = new Error('Error getting notebook info: ' + nbpath + ' - ' + err.message);
+    if (err.code === 'ENOENT') {
+        e.status = 404;
+    }
+    return e;
+}
+
+function _statNbOrDir(nbpath) {
+    return new Promise(function(resolve, reject) {
+        // try to stat a notebook first, then fallback to original value
+        var extPath = appendExt(nbpath, DB_EXT);
+        fs.stat(extPath, function(err, stats) {
+            if (err && extPath === nbpath) {
+                reject(_statError(err, nbpath));
+            } else if (stats && stats.isFile()) {
+                stats.fullpath = extPath;
+                resolve(stats); // notebook exists
+            } else {
+                // path may be a directory (bundled dashboard) or other file
+                fs.stat(nbpath, function(err, stats) {
+                    if (err) {
+                        reject(_statError(err, nbpath));
+                    } else {
+                        stats.fullpath = nbpath;
+                        resolve(stats);
+                    }
+                });
+            }
+        });
+    });
+}
+
+function _stat(nbpath) {
+    nbpath = _ensureDataPath(nbpath);
+    var ext = path.extname(nbpath);
+
+    return _statNbOrDir(nbpath).then(function(stats) {
+        if (stats.isDirectory()) {
+            // check if this directory contains an index dashboard
+            var indexPath = path.join(nbpath, INDEX_NB_NAME);
+            return _exists(indexPath).then(function (exists) {
+                stats.isDashboard = stats.hasIndex = exists;
+                if (stats.hasIndex) {
+                    stats.fullpath = indexPath;
+                    return new Promise(function(resolve) {
+                        // check if bundled dashboard has an 'urth_components' dir
+                        fs.stat(path.join(nbpath, 'urth_components'),
+                            function(err, urth_stats) {
+                                stats.supportsDeclWidgets = !err && urth_stats.isDirectory();
+                                resolve(stats);
+                            }
+                        );
+                    });
+                } else {
+                    return stats;
+                }
+            });
+        } else {
+            // might be a dashboard file or a "regular" file
+            stats.isDashboard = stats.isFile() && path.extname(stats.fullpath) === DB_EXT;
+            return stats;
+        }
+    });
+}
+
+module.exports = {
+    /**
+     * Checks if the specified file exists
+     * @param  {String} nbpath - path to a notebook
+     * @return {Promise(Boolean)} resolved to true if it exists
+     */
+    exists: _exists,
+    /**
+     * Runs `stat` on the specified path.
+     * @param {String} nbpath - Path to a notebook or directory.
+     *     If not relative to data directory, it will be made so.
+     * @return {Promise} resolved with the `stat` results. Will contain some custom properties:
+     *     {String} fullpath - absolute path of file (index path if bundled)
+     *     {Boolean} isDashboard - true if the path is a dashboard file or directory
+     *     {Boolean} hasIndex - true if the path contains an index dashboard
+     *     {Boolean} supportsDeclWidgets - true if the dashboard supports Declarative Widgets
+     */
+    stat: _stat
+};

--- a/app/notebook-fs.js
+++ b/app/notebook-fs.js
@@ -105,18 +105,18 @@ module.exports = {
     /**
      * Checks if the specified file exists
      * @param  {String} nbpath - path to a notebook
-     * @return {Promise(Boolean)} resolved to true if it exists
+     * @return {Promise.<boolean>} true if it exists
      */
     exists: _exists,
     /**
      * Runs `stat` on the specified path.
      * @param {String} nbpath - Path to a notebook or directory.
      *     If not relative to data directory, it will be made so.
-     * @return {Promise} resolved with the `stat` results. Will contain some custom properties:
+     * @return {Promise.<Object>} `stat` results. Contains some custom properties:
      *     {String} fullpath - absolute path of file (index path if bundled)
-     *     {Boolean} isDashboard - true if the path is a dashboard file or directory
-     *     {Boolean} hasIndex - true if the path contains an index dashboard
-     *     {Boolean} supportsDeclWidgets - true if the dashboard supports Declarative Widgets
+     *     {boolean} isDashboard - true if the path is a dashboard file or directory
+     *     {boolean} hasIndex - true if the path contains an index dashboard
+     *     {boolean} supportsDeclWidgets - true if the dashboard supports Declarative Widgets
      */
     stat: _stat
 };

--- a/app/notebook-store.js
+++ b/app/notebook-store.js
@@ -35,7 +35,7 @@ function _loadNb(nbpath, stats) {
             return new Promise(function(resolve, reject) {
                 fs.readFile(nbfile, ENCODING, function(err, rawData) {
                     if (err) {
-                        reject(err);
+                        reject(new Error('Error loading notebook: ' + err.message));
                     } else {
                         var nb = JSON.parse(rawData);
                         // cache notebook for future reads -- use given `nbpath` since that

--- a/app/notebook-store.js
+++ b/app/notebook-store.js
@@ -2,133 +2,53 @@
  * Copyright (c) Jupyter Development Team.
  * Distributed under the terms of the Modified BSD License.
  */
-var Busboy = require('busboy');
+var appendExt = require('./append-ext');
 var config = require('./config');
 var debug = require('debug')('dashboard-proxy:notebook-store');
-var extract = require('extract-zip');
 var fs = require('fs-extra');
+var nbfs = require('./notebook-fs');
 var path = require('path');
 var Promise = require('es6-promise').Promise;
-var tmp = require('tmp');
 
-var DB_EXT = config.get('DB_FILE_EXT');
 var DATA_DIR = config.get('NOTEBOOKS_DIR');
+var ENCODING = 'utf8';
 var INDEX_NB_NAME = config.get('DB_INDEX');
-var ZIP_EXT = '.zip';
+
 debug('store dir: ' + DATA_DIR);
 
-var allowedUploadExts = [ DB_EXT, ZIP_EXT ];
-
 // cached notebook objects
-var store = {};
+var _cache = {};
 
-/////////////////
-// GET OPERATIONS
-/////////////////
-
-// Append the notebook file extension if left off
-function _appendExt(nbpath) {
-    var ext = path.extname(nbpath) === DB_EXT ? '' : DB_EXT;
-    return nbpath + ext;
-}
-
-// determines if the specified file exists
-function exists(nbpath) {
-    return new Promise(function(resolve, reject) {
-        if (!path.isAbsolute(nbpath)) {
-            nbpath = path.join(DATA_DIR, nbpath);
-        }
-        nbpath = _appendExt(nbpath);
-        fs.stat(nbpath, function(err, stats) {
-            if (err) {
-                if (err.code === 'ENOENT') { // file not found
-                    resolve(false);
-                } else {
-                    reject(err);
-                }
-            } else {
-                resolve(stats.isFile());
-            }
-        });
-    });
-}
-
-// stat the path in the data directory
-function stat(nbpath) {
-    nbpath = path.join(DATA_DIR, nbpath);
-    return new Promise(function(resolve, reject) {
-        fs.stat(nbpath, function(err, stats) {
-            if (err) {
-                return reject(err);
-            }
-
-            stats.fullpath = nbpath;
-
-            if (stats.isDirectory()) {
-                // check if this directory contains an index dashboard
-                exists(path.join(nbpath, INDEX_NB_NAME)).then(
-                    function success(exists) {
-                        stats.isDashboard = stats.hasIndex = exists;
-                        if (stats.hasIndex) {
-                            // check if bundled dashboard has an 'urth_components' dir
-                            fs.stat(path.join(nbpath, 'urth_components'),
-                                function(err, urth_stats) {
-                                    stats.supportsDeclWidgets = !err && urth_stats.isDirectory();
-                                    resolve(stats);
-                                });
-                        } else {
-                            resolve(stats);
-                        }
-                    },
-                    function failure(err) {
-                        reject(err);
-                    }
-                );
-            } else {
-                // might be a dashboard file or a "regular" file
-                stats.isDashboard = stats.isFile() && path.extname(nbpath) === DB_EXT;
-                resolve(stats);
-            }
-        });
-    });
-}
+//////////////////
+// READ OPERATIONS
+//////////////////
 
 // Read notebook from cache or from file
 function _loadNb(nbpath, stats) {
     if (!stats) {
-        stats = stat(nbpath);
+        stats = nbfs.stat(nbpath);
     }
     return Promise.resolve(stats)
         .then(function(stats) {
-            var nbfile;
-            if (stats.hasIndex) {
-                nbfile = path.join(nbpath, INDEX_NB_NAME);
-            } else {
-                nbfile = _appendExt(nbpath);
-            }
-
+            var nbfile = stats.fullpath ||
+                path.join(DATA_DIR, appendExt(nbpath, DB_EXT));
             return new Promise(function(resolve, reject) {
-                var nbAbsPath = path.join(DATA_DIR, nbfile);
-                fs.readFile(nbAbsPath, 'utf8', function(err, rawData) {
+                fs.readFile(nbfile, ENCODING, function(err, rawData) {
                     if (err) {
-                        reject(new Error('Error loading notebook: ' + err.message));
+                        reject(err);
                     } else {
-                        try {
-                            var nb = JSON.parse(rawData);
-                            // cache notebook for future reads -- use given `nbpath` since that
-                            // is path from request. later calls will look up using request path.
-                            store[nbpath] = nb; 
-                            resolve(nb);
-                        } catch(e) {
-                            reject(new Error('Error parsing notebook JSON'));
-                        }
+                        var nb = JSON.parse(rawData);
+                        // cache notebook for future reads -- use given `nbpath` since that
+                        // is path from request. later calls will look up using request path.
+                        _cache[nbpath] = nb;
+                        resolve(nb);
                     }
                 });
             });
         });
 }
 
-function list(dir) {
+function _list(dir) {
     // list all (not hidden) children of the specified directory
     // (within the data directory)
     var dbpath = path.join(DATA_DIR, dir || '');
@@ -146,9 +66,9 @@ function list(dir) {
     });
 }
 
-function get(nbpath, stats) {
-    if (store.hasOwnProperty(nbpath)) {
-        return Promise.resolve(store[nbpath]);
+function _get(nbpath, stats) {
+    if (_cache.hasOwnProperty(nbpath)) {
+        return Promise.resolve(_cache[nbpath]);
     } else {
         return _loadNb(nbpath, stats);
     }
@@ -158,260 +78,26 @@ function get(nbpath, stats) {
 // DELETE OPERATIONS
 ////////////////////
 
-function remove(nbpath) {
-    delete store[nbpath];
-}
-
-////////////////////
-// UPLOAD OPERATIONS
-////////////////////
-
-var _uploadMessage = 'Make sure to upload a single Jupyter Notebook file (*.ipynb).';
-
-/**
- * Return absolute destination directory
- * @param  {Request} req
- * @return {String}
- */
-function _getDestination (req) {
-    // parse destination directory from request url
-    var nbdir = path.dirname(req.params[0]);
-    var destDir = path.join(DATA_DIR, nbdir);
-    return destDir;
-}
-
-function _fileFilter (filename) {
-    // check that file extension is in list of allowed upload file extensions
-    var ext = path.extname(filename).toLowerCase();
-    return allowedUploadExts.indexOf(ext) !== -1;
-}
-
-/**
- * Write file contents to specified location
- * 
- * @param  {String} destination - directory path which will contain uploaded dashboard
- * @param  {String} filename    - name of dashboard
- * @param  {Buffer} buffer      - contents of uploaded file
- * @return {Promise}
- */
-function _writeFile (destination, filename, buffer) {
-    return new Promise(function(resolve, reject) {
-        fs.mkdir(destination, function(err) {
-            if (err && err.code !== 'EEXIST') {
-                reject(err);
-            } else {
-                var destFilename = path.join(destination, filename);
-                debug('Uploading notebook: ' + destFilename);
-                fs.writeFile(destFilename, buffer, function(err) {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve();
-                    }
-                });
-            }
-        });
-    });
-}
-
-/**
- * Write zip archive contents to specified location
- * 
- * @param  {String} destination - directory path which will contain uploaded dashboard
- * @param  {String} filename    - name of dashboard
- * @param  {Buffer} buffer      - contents of uploaded zip archive
- * @return {Promise}
- */
-function _writeZipFile(destination, filename, buffer) {
-    // create a temporary directory in which to unzip archive
-    return new Promise(function(resolve, reject) {
-        tmp.dir({ unsafeCleanup: true }, function(err, tmpDir, cleanup) {
-            if (err) {
-                return reject(err);
-            }
-            resolve({
-                path: tmpDir,
-                cleanup: cleanup
-            });
-        });
-    })
-    .then(function(tempobj) {
-        var tmpDir = tempobj.path;
-        var tmpZip = path.join(tmpDir, filename + ZIP_EXT);
-        var tmpUnzipDir = path.join(path.dirname(tmpZip), path.basename(tmpZip, ZIP_EXT));
-
-        // write zip archive contents to filesystem
-        return _writeFile(tmpDir, path.basename(tmpZip), buffer)
-        // extract zip archive
-        .then(function() {
-            return new Promise(function(resolve, reject) {
-                extract(tmpZip, {dir: tmpUnzipDir}, function (err) {
-                    if (err) {
-                        return reject(err);
-                    }
-                    resolve(tmpUnzipDir);
-                });
-            });
-        })
-        // validate zip archive contents -- does it contain 'index.ipynb'?
-        .then(function(tmpUnzipDir) {
-            return new Promise(function(resolve, reject) {
-                fs.stat(path.join(tmpUnzipDir, INDEX_NB_NAME), function(err, stat) {
-                    if (!err && stat.isFile()) {
-                        return resolve(tmpUnzipDir);
-                    }
-                    reject(err);
-                });
-            });
-        })
-        // move unzipped contents to data directory, overwriting previously existing dir
-        .then(function(tmpUnzipDir) {
-            var destDir = path.join(destination, filename);
-
-            return new Promise(function(resolve, reject) {
-                fs.move(tmpUnzipDir, destDir, { clobber: true }, function(err) {
-                    if (err) {
-                        return reject(err);
-                    }
-                    resolve();
-                });
-            });
-        })
-        // cleanup on success or failure
-        .then(tempobj.cleanup, function failure(err) {
-            tempobj.cleanup();
-            throw err;
-        });
-    });
-}
-
-// busboy limits.
-// Busboy will ignore any files past the limit (and not throw an error), so to
-// send a descriptive error message when too many files are sent, lets set the
-// file limit to 2 and return an error if 2 files are sent.
-var _uploadLimits = {
-    fields: 0,
-    files: 2,
-    parts: 2
-};
-
-function upload(req, res, next) {
-    var buffers = [];
-    var bufferLength = 0;
-    var destination = _getDestination(req);
-    var filename = path.basename(req.params[0]);
-    var cachedPath = req.params[0];
-    var fileCount = 0;
-
-    // only allow 1 file and nothing else in the form
-    var busboy = new Busboy({
-        headers: req.headers,
-        limits: _uploadLimits
-    });
-
-    // handle file upload
-    var uploadPromise = null;
-    busboy.on('file', function(fieldname, file, originalname, encoding, mimetype) {
-        if (++fileCount > 1) {
-            // too many files, error
-            uploadPromise = Promise.reject(new Error('Too many files. ' + _uploadMessage));
-            file.resume();
-        } else {
-            uploadPromise = new Promise(function(resolve, reject) {
-                if (_fileFilter(originalname)) {
-                    debug('Reading file: ' + originalname);
-                    file.on('data', function(data) {
-                        debug('File [' + originalname + ']: received ' + data.length + ' bytes');
-                        buffers.push(data);
-                        bufferLength += data.length;
-                    });
-                    file.on('end', function() {
-                        debug('File [' + fieldname + '] Finished');
-                        var totalFile = Buffer.concat(buffers, bufferLength);
-                        var promise;
-
-                        // write the file correctly
-                        var extension = path.extname(originalname);
-                        if (extension === DB_EXT) {
-                            promise = _writeFile(destination, _appendExt(filename), totalFile);
-                        } else if (extension === '.zip') {
-                            promise = _writeZipFile(destination, filename, totalFile);
-                        }
-
-                        promise.then(resolve, function failure(err) {
-                            reject(new Error('Failed to upload file: ' + err.message));
-                        });
-                    });
-                    file.on('error', function(err) {
-                        reject(err);
-                    });
-                } else {
-                    file.resume();
-                    reject(new Error('Wrong file extension. ' + _uploadMessage));
-                }
-            });
-        }
-    });
-
-    // finish processing form
-    busboy.on('finish', function() {
-        debug('Finished reading form data');
-        if (uploadPromise) {
-            // a file was uploaded
-            uploadPromise.then(
-                function success() {
-                    // bust the notebook cache so it can load the new file
-                    remove(cachedPath);
-                    next();
-                },
-                function failure(err) {
-                    next(err);
-                }
-            );
-        } else {
-            // a file was not uploaded
-            next(new Error('No file provided. ' + _uploadMessage));
-        }
-    });
-
-    // start the form processing
-    req.pipe(busboy);
+function _uncache(nbpath) {
+    delete _cache[nbpath];
 }
 
 module.exports = {
     /**
-     * Checks if the specified file exists
-     * @param  {String} nbpath - path to a notebook
-     * @return {Promise(Boolean)} resolved to true if it exists
-     */
-    exists: exists,
-    /**
      * Loads, parses, and returns cells (minus code) of the notebook specified by nbpath
-     * @param  {String} nbpath - path of the notbeook to load
-     * @return {Promise} resolved with notebook JSON or error string
+     * @param  {String} nbpath - path of the notebook to load
+     * @return {Promise} resolved with notebook JSON and notebook absolute path
      */
-    get: get,
+    get: _get,
     /**
      * Lists contents of the specified directory
      * @param {String} dir - optional sub-directory to Lists
      * @return {Promise} resolved with list of contents
      */
-    list: list,
+    list: _list,
     /**
-     * Runs `stat` on the specified path
-     * @param {String} nbpath - path that may be a notebook or directory
-     * @return {Promise} resolved with the `stat` results. Will contain some custom properties:
-     *     {String} fullpath - absolute path of file/dir
-     *     {Boolean} isDashboard - true if the path is a dashboard file or directory
-     *     {Boolean} hasIndex - true if the path contains an index dashboard
-     *     {Boolean} supportsDeclWidgets - true if the dashboard supports Declarative Widgets
+     * Removes the specified notebook from the cache
+     * @param {String} nbpath - path of notebook to remove from cache
      */
-    stat: stat,
-    /**
-     * Uploads a notebook file
-     * @param {Request}  req - HTTP request object
-     * @param {Response} res - HTTP response object
-     * @param {Function} next - next function
-     */
-    upload: upload
+    uncache: _uncache
 };

--- a/app/notebook-store.js
+++ b/app/notebook-store.js
@@ -86,13 +86,13 @@ module.exports = {
     /**
      * Loads, parses, and returns cells (minus code) of the notebook specified by nbpath
      * @param  {String} nbpath - path of the notebook to load
-     * @return {Promise} resolved with notebook JSON and notebook absolute path
+     * @return {Promise.<Object>} notebook data
      */
     get: _get,
     /**
      * Lists contents of the specified directory
      * @param {String} dir - optional sub-directory to Lists
-     * @return {Promise} resolved with list of contents
+     * @return {Promise.<string[]>} list of contents
      */
     list: _list,
     /**

--- a/app/notebook-upload.js
+++ b/app/notebook-upload.js
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+var appendExt = require('./append-ext');
+var Busboy = require('busboy');
+var config = require('./config');
+var debug = require('debug')('dashboard-proxy:upload-notebook');
+var extract = require('extract-zip');
+var fs = require('fs-extra');
+var nbstore = require('./notebook-store');
+var path = require('path');
+var Promise = require('es6-promise').Promise;
+var tmp = require('tmp');
+
+var DATA_DIR = config.get('NOTEBOOKS_DIR');
+var DB_EXT = config.get('DB_FILE_EXT');
+var ENCODING = 'utf8';
+var INDEX_NB_NAME = config.get('DB_INDEX');
+var ZIP_EXT = '.zip';
+var ALLOWED_UPLOAD_EXTS = [ DB_EXT, ZIP_EXT];
+
+// busboy limits.
+// Busboy will ignore any files past the limit (and not throw an error), so to
+// send a descriptive error message when too many files are sent, lets set the
+// file limit to 2 and return an error if 2 files are sent.
+var _uploadLimits = {
+    fields: 0,
+    files: 2,
+    parts: 2
+};
+
+var _uploadMessage = 'Make sure to upload a single Jupyter Notebook file (*.ipynb).';
+
+function _fileFilter (filename) {
+    // check that file extension is in list of allowed upload file extensions
+    var ext = path.extname(filename).toLowerCase();
+    return ALLOWED_UPLOAD_EXTS.indexOf(ext) !== -1;
+}
+
+/**
+ * Write file contents to specified location
+ *
+ * @param  {String} destination - file path of uploaded dashboard
+ * @param  {Buffer} buffer      - contents of uploaded file
+ * @return {Promise}
+ */
+function _writeFile (destination, buffer) {
+    return new Promise(function(resolve, reject) {
+        fs.mkdir(path.dirname(destination), function(err) {
+            if (err && err.code !== 'EEXIST') {
+                reject(err);
+            } else {
+                debug('Uploading notebook: ' + destination);
+                fs.writeFile(destination, buffer, function(err) {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve();
+                    }
+                });
+            }
+        });
+    });
+}
+
+/**
+ * Write zip archive contents to specified location
+ *
+ * @param  {String} destination - directory of uploaded dashboard
+ * @param  {Buffer} buffer      - contents of uploaded zip archive
+ * @return {Promise}
+ */
+function _writeZipFile(destination, buffer) {
+    // create a temporary directory in which to unzip archive
+    return new Promise(function(resolve, reject) {
+        tmp.dir({ unsafeCleanup: true }, function(err, tmpDir, cleanup) {
+            if (err) {
+                return reject(err);
+            }
+            resolve({
+                path: tmpDir,
+                cleanup: cleanup
+            });
+        });
+    })
+    .then(function(tempobj) {
+        var tmpDir = tempobj.path;
+        var tmpZip = path.join(tmpDir, appendExt(path.basename(destination), ZIP_EXT));
+        var tmpUnzipDir = path.join(path.dirname(tmpZip), path.basename(tmpZip, ZIP_EXT));
+
+        // write zip archive contents to filesystem
+        return _writeFile(tmpZip, buffer)
+        // extract zip archive
+        .then(function() {
+            return new Promise(function(resolve, reject) {
+                extract(tmpZip, {dir: tmpUnzipDir}, function (err) {
+                    if (err) {
+                        return reject(err);
+                    }
+                    resolve(tmpUnzipDir);
+                });
+            });
+        })
+        // validate zip archive contents -- does it contain 'index.ipynb'?
+        .then(function(tmpUnzipDir) {
+            return new Promise(function(resolve, reject) {
+                fs.stat(path.join(tmpUnzipDir, INDEX_NB_NAME), function(err, stat) {
+                    if (!err && stat.isFile()) {
+                        return resolve(tmpUnzipDir);
+                    }
+                    reject(err);
+                });
+            });
+        })
+        // move unzipped contents to data directory, overwriting previously existing dir
+        .then(function(tmpUnzipDir) {
+            return new Promise(function(resolve, reject) {
+                fs.move(tmpUnzipDir, destination, { clobber: true }, function(err) {
+                    if (err) {
+                        return reject(err);
+                    }
+                    resolve();
+                });
+            });
+        })
+        // cleanup on success or failure
+        .then(tempobj.cleanup, function failure(err) {
+            tempobj.cleanup();
+            throw err;
+        });
+    });
+}
+
+/**
+ * Middleware function to upload a notebook file
+ * @param {Request}  req - HTTP request object
+ * @param {Response} res - HTTP response object
+ * @param {Function} next - next function
+ */
+module.exports = function (req, res, next) {
+    var buffers = [];
+    var bufferLength = 0;
+    var destination = path.join(DATA_DIR, req.params[0]);
+    var cachedPath = req.params[0];
+    var fileCount = 0;
+
+    // only allow 1 file and nothing else in the form
+    var busboy = new Busboy({
+        headers: req.headers,
+        limits: _uploadLimits
+    });
+
+    var uploadPromise = null;
+
+    // handle file upload
+    busboy.on('file', function(fieldname, file, originalname, encoding, mimetype) {
+        if (++fileCount > 1) {
+            // too many files, error
+            uploadPromise = Promise.reject(new Error('Too many files. ' + _uploadMessage));
+            file.resume();
+        } else {
+            uploadPromise = new Promise(function(resolve, reject) {
+                if (_fileFilter(originalname)) {
+                    debug('Reading file: ' + originalname);
+                    file.on('data', function(data) {
+                        debug('File [' + originalname + ']: received ' + data.length + ' bytes');
+                        buffers.push(data);
+                        bufferLength += data.length;
+                    });
+                    file.on('end', function() {
+                        debug('File [' + fieldname + '] Finished');
+                        var totalFile = Buffer.concat(buffers, bufferLength);
+
+                        // write the file correctly
+                        var extension = path.extname(originalname);
+                        var promise = Promise.reject('File not written');
+                        if (extension === DB_EXT) {
+                            promise = _writeFile(appendExt(destination, DB_EXT), totalFile);
+                        } else if (extension === '.zip') {
+                            promise = _writeZipFile(destination, totalFile);
+                        }
+                        promise.then(resolve, function failure(err) {
+                            reject(new Error('Failed to upload file: ' + err.message));
+                        });
+                    });
+                    file.on('error', function(err) {
+                        reject(err);
+                    });
+                } else {
+                    file.resume();
+                    reject(new Error('Wrong file extension. ' + _uploadMessage));
+                }
+            });
+        }
+    });
+
+    // finish processing form
+    busboy.on('finish', function() {
+        debug('Finished reading form data');
+        if (uploadPromise) {
+            // a file was uploaded
+            uploadPromise.then(
+                function success() {
+                    // clear the notebook cache so it can load the new file
+                    nbstore.uncache(cachedPath);
+                    next();
+                },
+                function failure(err) {
+                    next(err);
+                }
+            );
+        } else {
+            // a file was not uploaded
+            next(new Error('No file provided. ' + _uploadMessage));
+        }
+    });
+
+    // start the form processing
+    req.pipe(busboy);
+};

--- a/config.json
+++ b/config.json
@@ -22,7 +22,7 @@
     // Optional HTTPS certificate
     HTTPS_CERT_FILE: null
     // Directory that contains notebooks to serve as dashboards relative to
-    // the current working directory. Defaults to <package-dir>/data if left 
+    // the current working directory. Defaults to <package-dir>/data if left
     // unset.
     NOTEBOOKS_DIR: ""
     // Secret for authentication tokens
@@ -59,6 +59,6 @@
     DB_CELL_MARGIN: 10
     // Number of pixels in each row
     DB_DEFAULT_CELL_HEIGHT: 20
-    //Number of dashboard grid columns
+    // Number of dashboard grid columns
     DB_MAX_COLUMNS: 12
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,7 +130,8 @@ gulp.task('watch', function() {
 var nodemonOptions = {
     script: 'bin/jupyter-dashboards-server',
     ext: 'js handlebars coffee',
-    stdout: false
+    stdout: false,
+    ignore: ['data/*']
 };
 
 gulp.task('develop', ['build'], function () {

--- a/routes/auth-routes.js
+++ b/routes/auth-routes.js
@@ -6,16 +6,23 @@
  * Routes that make use of auth token
  */
 var authToken = require('../app/auth-token');
-var nbstore = require('../app/notebook-store');
+var config = require('../app/config');
+var upload = require('../app/notebook-upload');
 var router = require('express').Router();
+var urljoin = require('url-join');
+
+var GET_URL = urljoin(config.get('PUBLIC_LINK'), '/dashboards');
+var UPLOAD_MESSAGE = 'Notebook successfully uploaded';
 
 /* POST /notebooks/* - upload a dashboard notebook */
-router.post('/notebooks(/*)', authToken, nbstore.upload, function(req, res) {
-    res.status(201).json({
-        url: req.url,
+router.post('/notebooks(/*)', authToken, upload, function(req, res) {
+    var resBody = {
+        link: urljoin(GET_URL, req.params[0]),
+        message: UPLOAD_MESSAGE,
         status: 201,
-        message: 'Notebook successfully uploaded.'
-    });
+        url: req.url
+    };
+    res.status(201).json(resBody);
 });
 
 module.exports = router;

--- a/test/base/app/upload-notebook-test.js
+++ b/test/base/app/upload-notebook-test.js
@@ -51,7 +51,7 @@ EventMock.prototype.invoke = function(event, args) {
 
 var projectRoot = '../../../';
 var appDir = path.join(projectRoot, '/app');
-var nbstore = proxyquire(path.join(appDir, '/notebook-store'), {
+var nbupload = proxyquire(path.join(appDir, '/notebook-upload'), {
     './config': configStub,
     'fs-extra': fsStub,
     busboy: EventMock
@@ -69,7 +69,7 @@ function uploadFile(req, originalname, next) {
         busboy.invoke('file', ['', fileMock, originalname]);
         busboy.invoke('finish');
     };
-    nbstore.upload(req, null, next);
+    nbupload(req, null, next);
 }
 
 function uploadFileTest(uploadPath, originalname, finalname) {


### PR DESCRIPTION
`notebook-store.js` contained several utility functions that should be individual modules. I've split it apart accordingly and cleaned up the code a bit.

This also includes the addition of a public dashboard link which is used in https://github.com/jupyter-incubator/dashboards_bundlers/pull/37.