### PR TITLE
[Issue 218] Make public link a customizable pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@
 # Global params
 DASHBOARD_CONTAINER_NAME:=dashboard-server
 DASHBOARD_IMAGE_NAME:=jupyter-incubator/$(DASHBOARD_CONTAINER_NAME)
-DASHBOARD_SERVER_LINK?=http://$$(docker-machine ip $$(docker-machine active)):3000
 INSTALLED_DASHBOARD_IMAGE_NAME:=jupyter-incubator/$(DASHBOARD_CONTAINER_NAME)-installed
+PUBLIC_LINK_PATTERN:={protocol}://$$(docker-machine ip $$(docker-machine active)):{port}
 KG_IMAGE_NAME:=jupyter-incubator/kernel-gateway-extras
 KG_CONTAINER_NAME:=kernel-gateway
 HTTP_PORT?=3000
@@ -81,12 +81,12 @@ define DASHBOARD_SERVER
 	-p 9711:8080 \
 	-e USERNAME=$(USERNAME) \
 	-e PASSWORD=$(PASSWORD) \
+	-e PUBLIC_LINK_PATTERN=$(PUBLIC_LINK_PATTERN) \
 	-e PORT=$(HTTP_PORT) \
 	-e HTTPS_PORT=$(HTTPS_PORT) \
 	-e HTTPS_KEY_FILE=$(HTTPS_KEY_FILE) \
 	-e HTTPS_CERT_FILE=$(HTTPS_CERT_FILE) \
-	-e SESSION_SECRET_TOKEN=$(SESSION_SECRET_TOKEN) \
-	-e PUBLIC_LINK=$(DASHBOARD_SERVER_LINK)
+	-e SESSION_SECRET_TOKEN=$(SESSION_SECRET_TOKEN)
 endef
 
 ############### Kernel gateway in a Docker container

--- a/app/config.js
+++ b/app/config.js
@@ -75,10 +75,4 @@ if (key_file_location || cert_file_location) {
     });
 }
 
-// set base link
-if (!config.get('PUBLIC_LINK')) {
-    var _protocol = config.get('SSL_OPTIONS') ? 'https' : 'http';
-    config.set('PUBLIC_LINK', _protocol + '://' + config.get('IP') + ':' + config.get('PORT'));
-}
-
 module.exports = config;

--- a/app/public-link.js
+++ b/app/public-link.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+var config = require('./config');
+
+var PUBLIC_LINK_PATTERN = config.get('PUBLIC_LINK_PATTERN');
+var PROTOCOL = /\{protocol\}/g;
+var HOST = /\{host\}/g;
+var PORT = /\{port\}/g;
+
+/**
+ * Generates a base URL that can be used to build public links. Uses the pattern
+ * specified by the PUBLIC_LINK_PATTERN config parameter.
+ * @param  {Request} req - Express request used to get protocol and hostname
+ * @return {String} public base URL
+ * @return {undefined} if PUBLIC_LINK_PATTERN is not set
+ */
+module.exports = function(req) {
+    if (PUBLIC_LINK_PATTERN) {
+        return PUBLIC_LINK_PATTERN
+            .replace(PROTOCOL, req.protocol)
+            .replace(HOST, req.headers.host)
+            .replace(PORT, req.headers.host.split(':')[1] || '');
+    }
+};

--- a/config.json
+++ b/config.json
@@ -11,6 +11,14 @@
 
     // Mode in which the dashboard server express environment runs
     NODE_ENV: development
+    // Base URL pattern for building public link for an uploaded notebook.
+    // Supports placeholder strings (values come from request host header):
+    //   {protocol} - request protocol (HTTP or HTTPS)
+    //   {host} - value of the host header, (hostname[:port])
+    //   {port} - port extracted from the host header
+    // Examples using placeholders: {protocol}://{host}
+    //                              {protocol}://192.168.99.100:{port}
+    PUBLIC_LINK_PATTERN: http://127.0.0.1:3000
     // Interface on which the dashboard server listens
     IP: 127.0.0.1
     // Port on which the dashboard server listens

--- a/routes/auth-routes.js
+++ b/routes/auth-routes.js
@@ -7,21 +7,24 @@
  */
 var authToken = require('../app/auth-token');
 var config = require('../app/config');
+var link = require('../app/public-link');
 var upload = require('../app/notebook-upload');
 var router = require('express').Router();
 var urljoin = require('url-join');
 
-var GET_URL = urljoin(config.get('PUBLIC_LINK'), '/dashboards');
 var UPLOAD_MESSAGE = 'Notebook successfully uploaded';
 
 /* POST /notebooks/* - upload a dashboard notebook */
 router.post('/notebooks(/*)', authToken, upload, function(req, res) {
+    var publicLink = link(req);
     var resBody = {
-        link: urljoin(GET_URL, req.params[0]),
         message: UPLOAD_MESSAGE,
         status: 201,
         url: req.url
     };
+    if (publicLink) {
+        resBody.link = urljoin(publicLink, 'dashboards', req.params[0]);
+    }
     res.status(201).json(resBody);
 });
 


### PR DESCRIPTION
Allows {protocol}, {hostname}, and {port} placeholders in a PUBLIC_LINK_PATTERN config parameter

Upload API will build the public link based on this pattern and omit the link if the pattern is not set in the config

Resolves #218 