### PR TITLE
Remove antiquated '100vh' rule

### DIFF
--- a/client/less/dashboard.less
+++ b/client/less/dashboard.less
@@ -17,7 +17,6 @@ body {
     position: relative;
     padding: 15px 0;
     background-color: white;
-    min-height: 100vh;
 
     #dashboard-container {
         position: relative;


### PR DESCRIPTION
Causes page to always be taller than viewport, resulting
in unnecessary scrollbar for short pages.