### PR TITLE
[Issue: 221] matplotlib image is centered in dashboard server, left-justified in notebook

### DIFF
--- a/client/less/notebook.less
+++ b/client/less/notebook.less
@@ -95,6 +95,13 @@
     }
 }
 
+.jp-OutputArea.rendered_html {
+    img {
+        margin-left: 0;
+        margin-right: 0;
+    }
+}
+
 label {
     font-weight: normal;
 }


### PR DESCRIPTION

(c) Copyright IBM Corp. 2016