### PR TITLE
Fix extraneous cell padding

### DIFF
--- a/client/js/layout.js
+++ b/client/js/layout.js
@@ -65,9 +65,6 @@ var $ = require('jquery');
             sheet.insertRule('.dashboard-cell[data-layout-height="' + h + '"] { height: ' + height + '}', 0);
         }
 
-        // cell padding
-        sheet.insertRule('.dashboard-cell { padding: ' +
-            halfMargin + 'px ' + (halfMargin + 6) + 'px }', 0);
     }
 
     module.exports = {

--- a/etc/notebooks/test/test_padding.ipynb
+++ b/etc/notebooks/test/test_padding.ipynb
@@ -1,0 +1,157 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 6,
+       "height": 5,
+       "row": 0,
+       "width": 6
+      }
+     }
+    }
+   },
+   "source": [
+    "Check that there is equivalent spacing between grid cells in the dashboard server and the notebook server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true,
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 0,
+       "height": 10,
+       "row": 0,
+       "width": 3
+      }
+     }
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"width: 275px; height: 286px; background-color: red\"></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<div style=\"width: 263px; height: 278px; background-color: red\"></div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false,
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 3,
+       "height": 10,
+       "row": 10,
+       "width": 3
+      }
+     }
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"width: 263px; height: 278px; background-color: blue\"></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<div style=\"width: 263px; height: 278px; background-color: blue\"></div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false,
+    "urth": {
+     "dashboard": {
+      "layout": {
+       "col": 3,
+       "height": 10,
+       "row": 0,
+       "width": 3
+      }
+     }
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div style=\"width: 263px; height: 278px; background-color: green\"></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%html\n",
+    "<div style=\"width: 263px; height: 278px; background-color: green\"></div>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  },
+  "urth": {
+   "dashboard": {
+    "cellMargin": 10,
+    "defaultCellHeight": 20,
+    "layout": "grid",
+    "maxColumns": 12
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Dashboard preview in the 0.5.2 layout extension (which uses Gridstack) does not include any extra padding on cells:

![screen shot 2016-05-24 at 9 21 48 am](https://cloud.githubusercontent.com/assets/153745/15505386/4e9c721c-2191-11e6-8d34-92eb6fa3a138.png)

Our read-only Gridstack-light clone here in dashboard server dynamically adds padding which causes full cells to overflow and misalign (see right edge of table):

![screen shot 2016-05-24 at 9 21 06 am](https://cloud.githubusercontent.com/assets/153745/15505389/53ea5216-2191-11e6-9e19-90d7c3e8695f.png)

This PR removes the extra padding. @jhpedemonte, @dalogsdon any reason why it should remain?