### PR TITLE
Bump to notebook 4.2 in kernel image

### DIFF
--- a/Dockerfile.kernel
+++ b/Dockerfile.kernel
@@ -1,7 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-FROM jupyter/all-spark-notebook:f3028232e94a
+FROM jupyter/all-spark-notebook:8015c88c4b11
 
 # Collection versions in one place. Would like to use ARG, but docker verison on
 # travis does not yet support it.

--- a/Dockerfile.kernel
+++ b/Dockerfile.kernel
@@ -1,7 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-FROM jupyter/all-spark-notebook:2d878db5cbff
+FROM jupyter/all-spark-notebook:f3028232e94a
 
 # Collection versions in one place. Would like to use ARG, but docker verison on
 # travis does not yet support it.


### PR DESCRIPTION
For parity with other dev environments to reduce docker pulls