### PR TITLE
Sets body height to prevent "dropup" menus

### DIFF
--- a/client/less/dashboard.less
+++ b/client/less/dashboard.less
@@ -9,6 +9,7 @@ html {
     box-sizing: inherit;
 }
 body {
+    min-height: 100vh;
     font-size: 14px;
     margin: 0;
 }


### PR DESCRIPTION
Fixes jupyter-incubator/dashboards#278

Since cells are absolutely positioned, they don't affect the size of their parent/ancestor elements. This meant that `body` was quite small. The code that shows the dropdown menus would check if there was enough space to show below the widget; if not, it would show the menu above. This check was always showing not enough space. This change will set body to always take up at least the full viewport height.