### PR TITLE
Fix regression in title link nav

### DIFF
--- a/views/partials/nav.handlebars
+++ b/views/partials/nav.handlebars
@@ -6,7 +6,7 @@
 <nav class="navbar navbar-default">
     <div class="container">
         <div class="navbar-left-container">
-            <a class="navbar-brand" href="{{baseUrl}}" title="Home">Jupyter Dashboard</a>
+            <a class="navbar-brand" href="{{urlJoin '/' baseUrl}}" title="Home">Jupyter Dashboard</a>
         </div>
 
         <div class="navbar-right-container">


### PR DESCRIPTION
Handle the default case where baseUrl is empty. Otherwise, it just links back to the current page.