### PR TITLE
logging error msg for #500

### DIFF
--- a/app.js
+++ b/app.js
@@ -164,6 +164,7 @@ dbserver.use(function(err, req, res, next) {
         stacktrace = err.stack;
         if (status >= 500 && status < 600) {
             console.log('STACK:', err.stack);
+            console.log('ERROR:', err);
         }
     }
 


### PR DESCRIPTION
I lost a lot of time because the server was displaying in log 
`STACK: undefined` and jupyterhub was only showing `500: Internal Server Error`. After adding displaying explicit error msg I found out it was permissions issue 
`
Filed to upload file: EACCES: permission denied, open '/srv/dashboards/notebook/Untilted3.ipynb'
`
I think it would be useful to display whole error msg.

